### PR TITLE
refactor: replace RuntimeException with specific exceptions

### DIFF
--- a/src/main/java/in/connectwithsandeepan/marathon/batch/ResultItemProcessor.java
+++ b/src/main/java/in/connectwithsandeepan/marathon/batch/ResultItemProcessor.java
@@ -9,6 +9,7 @@ import in.connectwithsandeepan.marathon.entity.Checkpoint;
 import in.connectwithsandeepan.marathon.entity.Event;
 import in.connectwithsandeepan.marathon.entity.EventCategory;
 import in.connectwithsandeepan.marathon.entity.Result;
+import in.connectwithsandeepan.marathon.exception.ProcessorInitializationException;
 import in.connectwithsandeepan.marathon.exception.ResultValidationException;
 import in.connectwithsandeepan.marathon.repo.ResultRepository;
 import jakarta.validation.ConstraintViolation;
@@ -80,7 +81,7 @@ public class ResultItemProcessor implements ItemProcessor<ResultRequestDTO, Resu
 
             } catch (JsonProcessingException e) {
                 log.error("Failed to convert JSON to objects for event {}: {}", eventId, e.getMessage(), e);
-                throw new RuntimeException("Failed to initialize processor for event " + eventId, e);
+                throw new ProcessorInitializationException("Failed to initialize processor for event " + eventId, e);
             }
         }
     }

--- a/src/main/java/in/connectwithsandeepan/marathon/batch/ResultUploadJobService.java
+++ b/src/main/java/in/connectwithsandeepan/marathon/batch/ResultUploadJobService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import in.connectwithsandeepan.marathon.entity.Event;
 import in.connectwithsandeepan.marathon.entity.EventCategory;
+import in.connectwithsandeepan.marathon.exception.BatchStartException;
 import in.connectwithsandeepan.marathon.repo.EventCategoryRepository;
 import in.connectwithsandeepan.marathon.repo.EventRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -54,9 +55,9 @@ public class ResultUploadJobService {
 
         } catch (JobExecutionException e) {
             log.error("Failed to start result upload job: {}", e.getMessage(), e);
-            throw new RuntimeException("Failed to start batch job", e);
+            throw new BatchStartException("Failed to start batch job", e);
         } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
+            throw new BatchStartException(e);
         }
     }
 }

--- a/src/main/java/in/connectwithsandeepan/marathon/exception/BatchStartException.java
+++ b/src/main/java/in/connectwithsandeepan/marathon/exception/BatchStartException.java
@@ -1,0 +1,11 @@
+package in.connectwithsandeepan.marathon.exception;
+
+public class BatchStartException extends RuntimeException {
+    public BatchStartException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public BatchStartException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/in/connectwithsandeepan/marathon/exception/ProcessorInitializationException.java
+++ b/src/main/java/in/connectwithsandeepan/marathon/exception/ProcessorInitializationException.java
@@ -1,0 +1,7 @@
+package in.connectwithsandeepan.marathon.exception;
+
+public class ProcessorInitializationException extends RuntimeException {
+    public ProcessorInitializationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
This PR addresses the issue of improving error handling by replacing generic `RuntimeException` instances with more specific, custom exceptions.

### Changes made:
Created:
- `BatchStartException`: for failures during batch job startup.
- `ProcessorInitializationException`: for initialization failures in the result item processor.

Updated:
- `ResultUploadJobService.java`: replaced `RuntimeException` with `BatchStartException`.
- `ResultItemProcessor.java`: replaced `RuntimeException` with `ProcessorInitializationException`.