### PR TITLE
Refactor SecurityConfig

### DIFF
--- a/src/main/java/in/connectwithsandeepan/marathon/config/SecurityConfig.java
+++ b/src/main/java/in/connectwithsandeepan/marathon/config/SecurityConfig.java
@@ -33,23 +33,25 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity
                 .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(auth ->
-                    auth.requestMatchers("/api/v1/users").permitAll()
-                            .requestMatchers("/api/v1/**").permitAll()
-                            .requestMatchers("/api/v1/auth/login").permitAll()
-                            .requestMatchers("/api/v1/events/**").permitAll()
-                            .requestMatchers("/api/v1/**").permitAll()
-                            .requestMatchers("/api/v1/events").permitAll()
-                            .requestMatchers("/image").permitAll()
-                            .requestMatchers("swagger-ui.html", "/v3/api-docs/**", "/swagger-ui/**").permitAll()
-                            .anyRequest().hasAnyRole("USER", "ADMIN")
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/v1/auth/login",
+                                "/api/v1/users",
+                                "/api/v1/events",
+                                "/api/v1/events/**",
+                                "/api/v1/**",
+                                "/image",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**"
+                        ).permitAll()
+                        .anyRequest().hasAnyRole("USER", "ADMIN")
                 )
                 .exceptionHandling(ex -> ex.accessDeniedHandler(accessDeniedHandler))
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         return httpSecurity.build();
-
     }
 
     @Bean


### PR DESCRIPTION
 simplify request matchers in `authorizeHttpRequests` for better readability